### PR TITLE
Add a 413-specific error message to make for easier troubleshooting.

### DIFF
--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func postPaste(content []byte) (string, error) {
 	}
 
 	if resp.StatusCode == 413 {
-		return "", fmt.Errorf("%d: Payload Too Large. Make sure your proxy or load balancer allows request bodies as large as any file you wish to accept.", resp.StatusCode)
+		return "", fmt.Errorf("%d: Payload Too Large. Make sure your proxy or load balancer allows request bodies as large as any file you wish to accept", resp.StatusCode)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/main.go
+++ b/main.go
@@ -164,6 +164,10 @@ func postPaste(content []byte) (string, error) {
 		return "", fmt.Errorf("Unauthorized. Please check your username and pass. %d", resp.StatusCode)
 	}
 
+	if resp.StatusCode == 413 {
+		return "", fmt.Errorf("%d: Payload Too Large. Make sure your proxy or load balancer allows request bodies as large as any file you wish to accept.", resp.StatusCode)
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("reading response body failed: %v", err)


### PR DESCRIPTION
I've been happily using pastebinit for months, and suddenly this morning I got an error I hadn't seen before:

> parsing body as json failed: invalid character '<' looking for beginning of value

"That's odd," I thought. Tried another file. It worked. Tried a big file. It failed. Try a couple small files. They both worked. Try a couple big files. They both failed.

After a few experiments, I had it pinned:

`base64 /dev/urandom | head -c 1048576 > this-file-works`
`base64 /dev/urandom | head -c 1048577 > this-file-fails`

Anything 1MB (exactly) or under worked, and anything over 1MB failed. This sort of precision screamed "configuration" to me. So I did some digging and found that nginx, which sits in front of my pastebinit-server, responds to any request body over 1MB with a 413 Payload Too Large by default.

For any future readers: I fixed this by setting `client_max_body_size 0;`, which disables the check (a bigger number is a better solution -- I'm just still figuring out what that number should be in my setup).

I figured it'd be helpful, should someone else run into this, to provide an error message that points a bit more directly at the problem. With this PR, pastebinit now returns the following error when receiving a 413 response code:

> 413: Payload Too Large. Make sure your proxy or load balancer allows request bodies as large as any file you wish to accept.

P.S. Thank you for building this nifty tool!